### PR TITLE
Loosen up docker-hub-exporter probes

### DIFF
--- a/charts/docker-hub-exporter/Chart.yaml
+++ b/charts/docker-hub-exporter/Chart.yaml
@@ -4,7 +4,7 @@ description: Docker Hub exporter
 home: https://github.com/jessestuart/docker-hub-exporter
 icon: https://helm.wyrihaximus.net/images/charts/docker-hub-exporter.png
 type: application
-version: 0.2.2
+version: 0.2.3
 appVersion: d05df48
 maintainers:
   - name: WyriHaximus

--- a/charts/docker-hub-exporter/templates/deployment.yaml
+++ b/charts/docker-hub-exporter/templates/deployment.yaml
@@ -30,10 +30,16 @@ spec:
               containerPort: 9170
               protocol: TCP
           livenessProbe:
+            failureThreshold: 9
+            periodSeconds: 20
+            initialDelaySeconds: 20
             httpGet:
               path: /
               port: metrics
           readinessProbe:
+            failureThreshold: 9
+            periodSeconds: 20
+            initialDelaySeconds: 20
             httpGet:
               path: /
               port: metrics


### PR DESCRIPTION
This is not a mission critical service and can be unavailable once in a while as the metrics it provibes aren't needed to be minute to minute accurate