### PR TITLE
[horizontal-pod-autoscalers] Add controlled scale down

### DIFF
--- a/.github/workflows/helm-charts-test.yaml
+++ b/.github/workflows/helm-charts-test.yaml
@@ -31,7 +31,7 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Create kind cluster
-        uses: helm/kind-action@v1.0.0-alpha.3
+        uses: helm/kind-action@v1.0.0
         with:
           installLocalPathProvisioner: true
         # Only build a kind cluster if there are chart changes to test.

--- a/charts/horizontal-pod-autoscalers/Chart.yaml
+++ b/charts/horizontal-pod-autoscalers/Chart.yaml
@@ -4,7 +4,8 @@ description: Horizontal Pod Autoscalers library
 home: https://github.com/wyrihaximusnet/helm-charts
 icon: https://helm.wyrihaximus.net/images/charts/horizontal-pod-autoscalers.png
 type: library
-version: 0.1.0
+version: 0.2.0
+kubeVersion: ^1.18
 maintainers:
   - name: WyriHaximus
     email: helm@wyrihaximus.net

--- a/charts/horizontal-pod-autoscalers/README.md
+++ b/charts/horizontal-pod-autoscalers/README.md
@@ -25,5 +25,7 @@ replicas:
 
 ## Opinionated decisions
 
+* requires kubernetes ^1.18
 * 1024 max replica's
 * scales when average CPU usage goes above 50%
+* scaling down happens at one pod a minute

--- a/charts/horizontal-pod-autoscalers/templates/_hpa.yaml
+++ b/charts/horizontal-pod-autoscalers/templates/_hpa.yaml
@@ -11,6 +11,12 @@ spec:
     name: {{ .name }}
   minReplicas: {{ .replicas.min | default 2 }}
   maxReplicas: {{ .replicas.max | default 1024 }}
+  behavior:
+    scaleDown:
+      policies:
+        - type: Pods
+          value: 1
+          periodSeconds: 60
   metrics:
     - type: Resource
       resource:


### PR DESCRIPTION
Overwrites the default behavior of scaling down quickly,
it slowly scales down one pod a minute. Making a possible
scale up less dramatic when it's still scaling down.