### PR TITLE
Revert selector labels from commons

### DIFF
--- a/charts/commento/Chart.yaml
+++ b/charts/commento/Chart.yaml
@@ -4,7 +4,7 @@ description: Helm chart to install commento on a kubernetes cluster
 home: https://commento.io/
 icon: https://cdn.commento.io/images/logo.svg
 name: commento
-version: 0.1.2
+version: 0.1.3
 maintainers:
   - name: WyriHaximus
     email: helm@wyrihaximus.net

--- a/charts/commento/templates/deployment.yaml
+++ b/charts/commento/templates/deployment.yaml
@@ -8,11 +8,21 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      {{- include "commons.selectorLabels" . | nindent 6 }}
+      app: {{ template "commons.name" . }}
+      release: {{ .Release.Name }}
   template:
     metadata:
       labels:
-        {{- include "commons.labels" . | nindent 8 }}
+        app: {{ template "commons.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ template "commons.name" . }}
+        app.kubernetes.io/version: {{ .Chart.Version | quote }}
+        appRevision: {{ template "commons.nameRevision" . }}
+        chart: {{ template "commons.chart" . }}
+        helm.sh/chart: {{ template "commons.chart" . }}
+        release: {{ .Release.Name }}
+        releaseRevision: {{ .Release.Revision | quote }}
+        heritage: {{ .Release.Service }}
     spec:
       containers:
         - name: commento

--- a/charts/commento/templates/pod-disruption-budget.yaml
+++ b/charts/commento/templates/pod-disruption-budget.yaml
@@ -7,5 +7,6 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      {{- include "commons.selectorLabels" . | nindent 6 }}
+      app: {{ template "commons.name" . }}
+      release: {{ .Release.Name }}
 {{ end }}

--- a/charts/commento/templates/service.yaml
+++ b/charts/commento/templates/service.yaml
@@ -12,4 +12,5 @@ spec:
       protocol: TCP
       name: commento
   selector:
-    {{- include "commons.selectorLabels" . | nindent 6 }}
+    app: {{ template "commons.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/default-backend/Chart.yaml
+++ b/charts/default-backend/Chart.yaml
@@ -4,7 +4,7 @@ description: A Helm chart for Kubernetes
 home: https://github.com/wyrihaximusnet/docker-default-backend
 icon: https://helm.wyrihaximus.net/images/charts/default-backend.png
 type: application
-version: 0.4.3
+version: 0.4.4
 kubeVersion: ^1.18
 appVersion: random
 maintainers:

--- a/charts/default-backend/templates/deployment.yaml
+++ b/charts/default-backend/templates/deployment.yaml
@@ -8,7 +8,8 @@ metadata:
 spec:
   selector:
     matchLabels:
-      {{- include "commons.selectorLabels" . | nindent 6 }}
+      app: {{ template "commons.name" . }}
+      release: {{ .Release.Name }}
   replicas: {{ .Values.replicas }}
   template:
     metadata:
@@ -16,7 +17,16 @@ spec:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9696"
       labels:
-        {{- include "commons.labels" . | nindent 8 }}
+        app: {{ template "commons.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ template "commons.name" . }}
+        app.kubernetes.io/version: {{ .Chart.Version | quote }}
+        appRevision: {{ template "commons.nameRevision" . }}
+        chart: {{ template "commons.chart" . }}
+        helm.sh/chart: {{ template "commons.chart" . }}
+        release: {{ .Release.Name }}
+        releaseRevision: {{ .Release.Revision | quote }}
+        heritage: {{ .Release.Service }}
     spec:
       containers:
         - name: default-backend

--- a/charts/default-backend/templates/pod-disruption-budget.yaml
+++ b/charts/default-backend/templates/pod-disruption-budget.yaml
@@ -7,5 +7,6 @@ spec:
   maxUnavailable: 1
   selector:
     matchLabels:
-      {{- include "commons.selectorLabels" . | nindent 6 }}
+      app: {{ template "commons.name" . }}
+      release: {{ .Release.Name }}
 {{ end }}

--- a/charts/default-backend/templates/service.yaml
+++ b/charts/default-backend/templates/service.yaml
@@ -16,4 +16,5 @@ spec:
       protocol: TCP
       name: metrics
   selector:
-    {{- include "commons.selectorLabels" . | nindent 6 }}
+    app: {{ template "commons.name" . }}
+    release: {{ .Release.Name }}

--- a/charts/docker-hub-exporter/Chart.yaml
+++ b/charts/docker-hub-exporter/Chart.yaml
@@ -4,7 +4,7 @@ description: Docker Hub Exporter
 home: https://github.com/jessestuart/docker-hub-exporter
 icon: https://helm.wyrihaximus.net/images/charts/docker-hub-exporter.png
 type: application
-version: 0.5.3
+version: 0.5.4
 appVersion: d05df48
 maintainers:
   - name: WyriHaximus

--- a/charts/docker-hub-exporter/templates/deployment.yaml
+++ b/charts/docker-hub-exporter/templates/deployment.yaml
@@ -8,14 +8,24 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      {{- include "commons.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/name: {{ include "commons.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9170"
       labels:
-        {{- include "commons.labels" . | nindent 8 }}
+        app: {{ template "commons.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ template "commons.name" . }}
+        app.kubernetes.io/version: {{ .Chart.Version | quote }}
+        appRevision: {{ template "commons.nameRevision" . }}
+        chart: {{ template "commons.chart" . }}
+        helm.sh/chart: {{ template "commons.chart" . }}
+        release: {{ .Release.Name }}
+        releaseRevision: {{ .Release.Revision | quote }}
+        heritage: {{ .Release.Service }}
     spec:
       containers:
         - name: docker-hub-exporter

--- a/charts/docker-hub-exporter/templates/pod-disruption-budget.yaml
+++ b/charts/docker-hub-exporter/templates/pod-disruption-budget.yaml
@@ -7,5 +7,6 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      {{- include "commons.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/name: {{ include "commons.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
 {{ end }}

--- a/charts/docker-hub-exporter/templates/service.yaml
+++ b/charts/docker-hub-exporter/templates/service.yaml
@@ -12,4 +12,5 @@ spec:
       protocol: TCP
       name: metrics
   selector:
-    {{- include "commons.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "commons.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/pi-hole-exporter/Chart.yaml
+++ b/charts/pi-hole-exporter/Chart.yaml
@@ -4,7 +4,7 @@ description: Pi-Hole Exporter
 home: https://github.com/eko/pihole-exporter
 icon: https://helm.wyrihaximus.net/images/charts/pi-hole-exporter.png
 type: application
-version: 0.1.1
+version: 0.1.2
 appVersion: d05df48
 maintainers:
   - name: WyriHaximus

--- a/charts/pi-hole-exporter/templates/deployment.yaml
+++ b/charts/pi-hole-exporter/templates/deployment.yaml
@@ -8,14 +8,24 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      {{- include "commons.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/name: {{ include "commons.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "9617"
       labels:
-        {{- include "commons.labels" . | nindent 8 }}
+        app: {{ template "commons.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ template "commons.name" . }}
+        app.kubernetes.io/version: {{ .Chart.Version | quote }}
+        appRevision: {{ template "commons.nameRevision" . }}
+        chart: {{ template "commons.chart" . }}
+        helm.sh/chart: {{ template "commons.chart" . }}
+        release: {{ .Release.Name }}
+        releaseRevision: {{ .Release.Revision | quote }}
+        heritage: {{ .Release.Service }}
     spec:
       containers:
         - name: pi-hole-exporter

--- a/charts/pi-hole-exporter/templates/pod-disruption-budget.yaml
+++ b/charts/pi-hole-exporter/templates/pod-disruption-budget.yaml
@@ -7,5 +7,6 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      {{- include "commons.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/name: {{ include "commons.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
 {{ end }}

--- a/charts/pi-hole-exporter/templates/service.yaml
+++ b/charts/pi-hole-exporter/templates/service.yaml
@@ -12,4 +12,5 @@ spec:
       protocol: TCP
       name: metrics
   selector:
-    {{- include "commons.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "commons.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}

--- a/charts/redirect/Chart.yaml
+++ b/charts/redirect/Chart.yaml
@@ -4,7 +4,7 @@ description: Redirect
 home: https://github.com/wyrihaximusnet/docker-redirect
 icon: https://helm.wyrihaximus.net/images/charts/redirect.png
 type: application
-version: 0.9.3
+version: 0.9.4
 kubeVersion: ^1.18
 appVersion: random
 maintainers:

--- a/charts/redirect/templates/deployment.yaml
+++ b/charts/redirect/templates/deployment.yaml
@@ -9,14 +9,24 @@ spec:
   replicas: {{ .Values.replicas }}
   selector:
     matchLabels:
-      {{- include "commons.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/name: {{ include "commons.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
   template:
     metadata:
       annotations:
         prometheus.io/scrape: "true"
         prometheus.io/port: "7133"
       labels:
-        {{- include "commons.labels" . | nindent 8 }}
+        app: {{ template "commons.name" . }}
+        app.kubernetes.io/instance: {{ .Release.Name }}
+        app.kubernetes.io/name: {{ template "commons.name" . }}
+        app.kubernetes.io/version: {{ .Chart.Version | quote }}
+        appRevision: {{ template "commons.nameRevision" . }}
+        chart: {{ template "commons.chart" . }}
+        helm.sh/chart: {{ template "commons.chart" . }}
+        release: {{ .Release.Name }}
+        releaseRevision: {{ .Release.Revision | quote }}
+        heritage: {{ .Release.Service }}
         {{- toYaml .Values.labels | nindent 8 }}
     spec:
     {{- with .Values.imagePullSecrets }}

--- a/charts/redirect/templates/pod-disruption-budget.yaml
+++ b/charts/redirect/templates/pod-disruption-budget.yaml
@@ -7,5 +7,6 @@ spec:
   minAvailable: 1
   selector:
     matchLabels:
-      {{- include "commons.selectorLabels" . | nindent 6 }}
+      app.kubernetes.io/name: {{ include "commons.name" . }}
+      app.kubernetes.io/instance: {{ .Release.Name }}
 {{ end }}

--- a/charts/redirect/templates/service.yaml
+++ b/charts/redirect/templates/service.yaml
@@ -16,4 +16,5 @@ spec:
       protocol: TCP
       name: http-metrics
   selector:
-    {{- include "commons.selectorLabels" . | nindent 4 }}
+    app.kubernetes.io/name: {{ include "commons.name" . }}
+    app.kubernetes.io/instance: {{ .Release.Name }}


### PR DESCRIPTION
The initial commit that changed this mistakenly assumed all selectors where the same. This commit reverts that. As selector labels are immutable they cannot be changed.

However they will be in a future release to the desired selector labels. A guide on how to do the migration will be included when the time comes.